### PR TITLE
fix(frontend): Use relative path for API base URL

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2,7 +2,7 @@ class VideoTranscriber {
     constructor() {
         this.currentTaskId = null;
         this.eventSource = null;
-        this.apiBase = 'http://localhost:8000/api';
+        this.apiBase = '/api';
         this.currentLanguage = 'en'; // 默认英文
         
         // 智能进度模拟相关


### PR DESCRIPTION
The API base URL was hardcoded to 'http://localhost:8000', which caused requests to fail with ERR_CONNECTION_REFUSED when the app was accessed from other devices on the local network (via IP).

This commit changes the base URL to a relative path ('/api') to ensure it works from both localhost and LAN.

API 基础 URL 被硬编码为 'http://localhost:8000'，
这导致当从局域网（通过IP）访问应用时，
请求会因 ERR_CONNECTION_REFUSED 而失败。

本次提交将基础 URL 更改为相对路径 ('/api')，
以确保它在 localhost 和局域网访问时都能正常工作。